### PR TITLE
_Dbg_copies: Use variable _Dbg_result instead of result to avoid side-effects with the debugged script.

### DIFF
--- a/lib/fns.sh
+++ b/lib/fns.sh
@@ -22,15 +22,15 @@
 typeset -a _Dbg_yn; _Dbg_yn=("n" "y")
 
 # Return $2 copies of $1. If successful, $? is 0 and the return value
-# is in result.  Otherwise $? is 1 and result ''
+# is in _Dbg_result.  Otherwise $? is 1 and _Dbg_result ''
 function _Dbg_copies {
-    result=''
+    _Dbg_result=''
     (( $# < 2 )) && return 1
     typeset -r string="$1"
     typeset -i count=$2 || return 2
     (( count > 0 )) || return 3
-    builtin printf -v result "%${count}s" ' ' || return 3
-    result=${result// /$string}
+    builtin printf -v _Dbg_result "%${count}s" ' ' || return 3
+    _Dbg_result=${_Dbg_result// /$string}
     return 0
 }
 

--- a/lib/processor.sh
+++ b/lib/processor.sh
@@ -115,15 +115,15 @@ function _Dbg_process_commands {
     # Set up prompt to show shell and subshell levels.
     typeset _Dbg_greater=''
     typeset _Dbg_less=''
-    typeset result  # Used by copies to return a value.
+    typeset _Dbg_result  # Used by _Dbg_copies to return a value.
 
     if _Dbg_copies '>' $_Dbg_DEBUGGER_LEVEL ; then
-        _Dbg_greater=$result
-        _Dbg_less=${result//>/<}
+        _Dbg_greater=$_Dbg_result
+        _Dbg_less=${_Dbg_result//>/<}
     fi
     if _Dbg_copies ')' $BASH_SUBSHELL ; then
-        _Dbg_greater="${result}${_Dbg_greater}"
-        _Dbg_less="${_Dbg_less}${result//)/(}"
+        _Dbg_greater="${_Dbg_result}${_Dbg_greater}"
+        _Dbg_less="${_Dbg_less}${_Dbg_result//)/(}"
     fi
 
     # Loop over debugger commands. But before reading a debugger

--- a/test/unit/test-fns.sh.in
+++ b/test/unit/test-fns.sh.in
@@ -3,7 +3,7 @@
 
 test_fns_copies()
 {
-    typeset result='bogus'
+    typeset _Dbg_result='bogus'
 
 #     _Dbg_copies 'a' 'b'
 #     assertFalse '_Dbg_copies "a" "b" should fail' "$?"
@@ -13,11 +13,11 @@ test_fns_copies()
 
     _Dbg_copies 'a' 3
     assertTrue '_Dbg_copies "a" 3 should succeed' "$?"
-    assertEquals 'aaa' $result
+    assertEquals 'aaa' $_Dbg_result
 
     _Dbg_copies ' ab' 4
     assertTrue '_Dbg_copies " ab" 4 should succeed' "$?"
-    assertEquals ' ab ab ab ab' "$result"
+    assertEquals ' ab ab ab ab' "$_Dbg_result"
 }
 
 test_fns_defined()


### PR DESCRIPTION
_Dbg_copies: Use variable _Dbg_result instead of result to avoid side-effects with the debugged script.